### PR TITLE
fixing incorrect kill's signal name

### DIFF
--- a/src/extension/ScriptRunner.ts
+++ b/src/extension/ScriptRunner.ts
@@ -143,7 +143,7 @@ export class ScriptRunner {
     const command =
       os.platform() === 'win32'
         ? `taskkill -F -T -PID ${pid}`
-        : `kill -SIGTERM ${pid}`
+        : `kill -15 ${pid}`
 
     exec(command)
   }


### PR DESCRIPTION
It's better to use the signal as a number (15) instead of full name as Linux and osx have different signal names "SIGTERM" in Linux and  "TERM" in osx