### PR TITLE
fixed bug:  SolidityFileName.sol:ContractName now shown in files

### DIFF
--- a/src/extension/utils/createAndOpenConfFile.ts
+++ b/src/extension/utils/createAndOpenConfFile.ts
@@ -34,9 +34,16 @@ function convertSourceFormDataToConfFileJSON(
   }
 
   if (inputFormData.mainSolidityFile) {
-    config.files.push(
-      `${inputFormData.mainSolidityFile}:${inputFormData.mainContractName}`,
-    )
+    if (
+      inputFormData.mainContractName &&
+      inputFormData.mainContractName.length > 0
+    ) {
+      config.files.push(
+        `${inputFormData.mainSolidityFile}:${inputFormData.mainContractName}`,
+      )
+    } else {
+      config.files.push(inputFormData.mainSolidityFile)
+    }
   }
 
   if (

--- a/src/extension/utils/createAndOpenConfFile.ts
+++ b/src/extension/utils/createAndOpenConfFile.ts
@@ -34,10 +34,7 @@ function convertSourceFormDataToConfFileJSON(
   }
 
   if (inputFormData.mainSolidityFile) {
-    if (
-      inputFormData.mainContractName &&
-      inputFormData.mainContractName.length > 0
-    ) {
+    if (inputFormData.mainContractName) {
       config.files.push(
         `${inputFormData.mainSolidityFile}:${inputFormData.mainContractName}`,
       )

--- a/src/extension/utils/createAndOpenConfFile.ts
+++ b/src/extension/utils/createAndOpenConfFile.ts
@@ -34,7 +34,9 @@ function convertSourceFormDataToConfFileJSON(
   }
 
   if (inputFormData.mainSolidityFile) {
-    config.files.push(inputFormData.mainSolidityFile)
+    config.files.push(
+      `${inputFormData.mainSolidityFile}:${inputFormData.mainContractName}`,
+    )
   }
 
   if (


### PR DESCRIPTION
Here I'm suggesting a solution to the bug: 

> Configuration file does not include the contract name

in the configuration file.