### PR TITLE
Todo before release

### DIFF
--- a/src/extension/SettingsPanel.ts
+++ b/src/extension/SettingsPanel.ts
@@ -233,9 +233,16 @@ export class SettingsPanel {
       if (fileUri && fileUri[0]) {
         const file = fileUri[0].fsPath.replace(uri.path + '/', '')
         const fileArr = file.split('/')
-        const label = fileArr.reverse()[0].split('.')[0]
+        const labelTypeArr = fileArr.reverse()[0].split('.')
+        const label = labelTypeArr[0]
         const path = fileArr[0]
-        const fileInFormat = { value: file, label: label, path: path }
+        const type = labelTypeArr[1]
+        const fileInFormat = {
+          value: file,
+          label: label,
+          path: path,
+          type: type,
+        }
         this._panel.webview.postMessage({
           type: 'file-chosen',
           payload: {

--- a/src/extension/SettingsPanel.ts
+++ b/src/extension/SettingsPanel.ts
@@ -236,7 +236,7 @@ export class SettingsPanel {
         const labelTypeArr = fileArr.reverse()[0].split('.')
         const label = labelTypeArr[0]
         const path = fileArr[0]
-        const type = labelTypeArr[1]
+        const type = '.' + labelTypeArr[1]
         const fileInFormat = {
           value: file,
           label: label,

--- a/src/extension/SettingsPanel.ts
+++ b/src/extension/SettingsPanel.ts
@@ -231,10 +231,15 @@ export class SettingsPanel {
 
     vscode.window.showOpenDialog(options).then(fileUri => {
       if (fileUri && fileUri[0]) {
+        const file = fileUri[0].fsPath.replace(uri.path + '/', '')
+        const fileArr = file.split('/')
+        const label = fileArr.reverse()[0].split('.')[0]
+        const path = fileArr[0]
+        const fileInFormat = { value: file, label: label, path: path }
         this._panel.webview.postMessage({
           type: 'file-chosen',
           payload: {
-            file: fileUri[0].fsPath.replace(uri.path + '/', ''),
+            file: fileInFormat,
             index: index,
           },
         })

--- a/src/settings/App.svelte
+++ b/src/settings/App.svelte
@@ -83,22 +83,18 @@
         info: e.data.payload,
       })
       const fileName = e.data.payload.file
-      const contractName = fileName
-        .toString()
-        .split('/')
-        .reverse()[0]
-        .replace('.sol', '')
+      const contractName = fileName.label
       const index = e.data.payload.index
-      if (fileName.endsWith('.sol')) {
+      if (fileName.type === 'sol') {
         if (index === -1) {
-          $solidityObj.mainFile = fileName
+          $solidityObj.mainFile = fileName.value
           $solidityObj.mainContract = contractName
         } else if ($solAdditionalContracts.length > index) {
           $solAdditionalContracts[index].mainFile = fileName
           $solAdditionalContracts[index].mainContract = contractName
         }
-      } else if (fileName.endsWith('.spec')) {
-        $specObj.specFile = fileName
+      } else if (fileName.type === 'spec') {
+        $specObj.specFile = fileName as unknown as string
       }
     }
   }

--- a/src/settings/App.svelte
+++ b/src/settings/App.svelte
@@ -85,7 +85,7 @@
       const fileName = e.data.payload.file
       const contractName = fileName.label
       const index = e.data.payload.index
-      if (fileName.type === 'sol') {
+      if (fileName.type === '.sol') {
         if (index === -1) {
           $solidityObj.mainFile = fileName.value
           $solidityObj.mainContract = contractName
@@ -93,8 +93,12 @@
           $solAdditionalContracts[index].mainFile = fileName
           $solAdditionalContracts[index].mainContract = contractName
         }
-      } else if (fileName.type === 'spec') {
-        $specObj.specFile = fileName as unknown as string
+      } else if (fileName.type === '.spec') {
+        $specObj.specFile = {
+          value: fileName.value,
+          label: fileName.label,
+          type: fileName.type,
+        } as unknown as string
       }
     }
   }

--- a/src/settings/RunSideNav.svelte
+++ b/src/settings/RunSideNav.svelte
@@ -50,7 +50,7 @@
     on:click={() => selectNavMenu('specCheck')}
     class:checked={$specObj.specFile !== ''}
     class:active={$navState.specCheck.active}
-    disabled={!solDisabledState}
+    disabled={false}
   >
     <i class="codicon codicon-symbol-method" />
     <h3>Certora spec</h3>
@@ -61,7 +61,7 @@
     on:click={() => selectNavMenu('msgCheck')}
     class:checked={$verification_message !== ''}
     class:active={$navState.msgCheck.active}
-    disabled={$specObj.specFile == ''}
+    disabled={false}
   >
     <i class="codicon codicon-comment " />
     <h3>Verification message</h3>

--- a/src/settings/SpecSettingsTab.svelte
+++ b/src/settings/SpecSettingsTab.svelte
@@ -189,7 +189,9 @@
             <i class="codicon codicon-file" />
             <h3>Main Spec File</h3>
             <h3 style="margin-left: auto; margin-right: 0; margin-top: 2px">
-              {JSON.parse(JSON.stringify($specObj.specFile)).label || ''}
+              {JSON.parse(JSON.stringify($specObj.specFile)).label
+                ? JSON.parse(JSON.stringify($specObj.specFile)).label + '.spec'
+                : ''}
             </h3>
           </div>
           <div slot="body" class="p-12 pt-0">

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -139,7 +139,7 @@ export type EventsFromExtension =
     }
   | {
       type: EventTypesFromExtension.FileChosen
-      payload: { file: string; index: number }
+      payload: { file: FileFormat; index: number }
     }
   | {
       type: EventTypesFromExtension.notifyWebviewAboutUpdates


### PR DESCRIPTION
=== before release, this tasks need to be complete ===
1. The most annoying thing by far for me is not being able to jump freely between the spec sections and the contract section. I actually like to start with the spec first! But most of all, I want the freedom to jump between the sections however I like. You can have some graphical indication that the section is not completed yet instead of not allowing to jump. Because then the user will find a way - they’ll fill-in dummy info, go to the other section, and submit and forget to update in the 1st section. That’s bad. 

2. Give some visible link to the output URL if we run on the cloud. It has better capabilities after all… did I miss it?

3. More critically, long paths look ugly - see picture. Please truncate them (show suffix) 

4. Feedback form leads to a google doc I cannot access. Needs to be fixed.