### PR TITLE
some small fixes CERT-2060

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+### 0.1.8 ()
+
+### Bug Fixes
+
+* The extension wont add nonsense filed to the conf ([#101](https://github.com/Certora/vscode-certora-prover/pull/101))
+* Duplicate button works on jobs that were converted from shell scripts ([#101](https://github.com/Certora/vscode-certora-prover/pull/101))
+
 ### 0.1.7 (2023-05-01)
 
 ## Bug Fixes

--- a/src/extension/utils/createConfFile.ts
+++ b/src/extension/utils/createConfFile.ts
@@ -240,10 +240,6 @@ export function newFormToConf(newForm: NewForm): string {
     )
   }
 
-  if (newForm.specObj.sendOnly) {
-    config.send_only = setAdditionalSetting(newForm.specObj.sendOnly.toString())
-  }
-
   if (newForm.specObj.duration) {
     config.smt_timeout = setAdditionalSetting(newForm.specObj.duration)
   }
@@ -293,8 +289,10 @@ export async function createConfFile(
 ): Promise<void> {
   try {
     const basePath = workspace.workspaceFolders?.[0]
-
     if (!basePath) return
+    formData.specObj.properties = formData.specObj.properties.filter(prop => {
+      return prop.name !== ''
+    })
 
     const encoder = new TextEncoder()
     const convertedData = newFormToConf(formData)

--- a/src/results/components/NewRun.svelte
+++ b/src/results/components/NewRun.svelte
@@ -138,7 +138,7 @@
   }
 
   function spacesToUnderscores(name: string): string {
-    return name.replaceAll(' ', '_').toLocaleLowerCase()
+    return name.replaceAll(' ', '_')
   }
 
   function onChange(

--- a/src/settings/utils/confFileToFormData.ts
+++ b/src/settings/utils/confFileToFormData.ts
@@ -223,8 +223,6 @@ function processSpecAttributes(confFile: ConfFile, specObj: SpecObj) {
       specObj.ruleSanity = true
       specObj.advancedSanity = true
     }
-    specObj.sendOnly = true
-    specObj.runSource = 'VSCODE'
   }
 
   const additionalSettings = getAdditionalSettings(confFile)


### PR DESCRIPTION
This PR fixes the following:
* send_only flag was added to the conf by the extension --> now it doesn't
* sometimes the extension added "":true to the conf --> now it doesn't
* specific edge case of "duplicate" didn't create a new conf (bug) --> now it does!